### PR TITLE
Etc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "[typescript]": {
+    "editor.formatOnSave": true
+  },
+  "[typescriptreact]": {
+    "editor.formatOnSave": true
+  }
+}

--- a/services/web/src/app/queries/chats.ts
+++ b/services/web/src/app/queries/chats.ts
@@ -1,0 +1,18 @@
+import * as redis from "@coops/redis";
+
+import { fetchWrapper } from "../utils/fetchWrapper";
+
+export const pushChat = (roomId: string, authorId: string, message: string) => {
+  return fetchWrapper<void>({
+    url: `/api/rooms/${roomId}/chat`,
+    method: "POST",
+    body: { message },
+    authorId,
+  });
+};
+export const getAllChats = (roomId: string, authorId: string) => {
+  return fetchWrapper<redis.chat.types.Chat[]>({
+    url: `/api/rooms/${roomId}/chat`,
+    authorId,
+  });
+};

--- a/services/web/src/app/queries/participants.ts
+++ b/services/web/src/app/queries/participants.ts
@@ -1,0 +1,76 @@
+import * as redis from "@coops/redis";
+
+import { fetchWrapper } from "../utils/fetchWrapper";
+
+export const createParticipant = (roomId: string, nickname: string) => {
+  return fetchWrapper<redis.participant.types.Participant>({
+    url: `/api/rooms/${roomId}/participants/${nickname}`,
+    method: "POST",
+  });
+};
+export const kickParticipant = (
+  roomId: string,
+  nickname: string,
+  authorId: string,
+) => {
+  return fetchWrapper<void>({
+    url: `/api/rooms/${roomId}/participants/${nickname}`,
+    method: "DELETE",
+    authorId,
+  });
+};
+export const entrustHost = (
+  roomId: string,
+  nickname: string,
+  authorId: string,
+) => {
+  return fetchWrapper<void>({
+    url: `/api/rooms/${roomId}/host/${nickname}`,
+    method: "PUT",
+    authorId,
+  });
+};
+export const unmuteMicrophone = (
+  roomId: string,
+  nickname: string,
+  authorId: string,
+) => {
+  return fetchWrapper<void>({
+    url: `/api/rooms/${roomId}/participants/${nickname}/microphone`,
+    method: "PUT",
+    authorId,
+  });
+};
+export const muteMicrophone = (
+  roomId: string,
+  nickname: string,
+  authorId: string,
+) => {
+  return fetchWrapper<void>({
+    url: `/api/rooms/${roomId}/participants/${nickname}/microphone`,
+    method: "DELETE",
+    authorId,
+  });
+};
+export const unmuteSpeaker = (
+  roomId: string,
+  nickname: string,
+  authorId: string,
+) => {
+  return fetchWrapper<void>({
+    url: `/api/rooms/${roomId}/participants/${nickname}/speaker`,
+    method: "PUT",
+    authorId,
+  });
+};
+export const muteSpeaker = (
+  roomId: string,
+  nickname: string,
+  authorId: string,
+) => {
+  return fetchWrapper<void>({
+    url: `/api/rooms/${roomId}/participants/${nickname}/speaker`,
+    method: "DELETE",
+    authorId,
+  });
+};

--- a/services/web/src/app/queries/rooms.ts
+++ b/services/web/src/app/queries/rooms.ts
@@ -1,0 +1,40 @@
+import type * as redis from "@coops/redis";
+
+import { fetchWrapper } from "../utils/fetchWrapper";
+
+export const createRoom = (title: string) => {
+  return fetchWrapper<{ roomId: string }>({
+    url: `/api/room/title/${title}`,
+    method: "POST",
+  });
+};
+export const getRoom = (roomId: string, authorId?: string) => {
+  return fetchWrapper<{
+    roomId: string;
+    title: string;
+    description: string;
+    maximumParticipants: number;
+    participants: Omit<redis.participant.types.Participant, "participantId">[];
+    chats: string[];
+  }>({
+    url: `/api/rooms/${roomId}`,
+    authorId,
+  });
+};
+export const resetRoom = (roomId: string, authorId: string) => {
+  return fetchWrapper<{ roomId: string }>({
+    url: `/api/rooms/${roomId}`,
+    authorId,
+  });
+};
+export const updateRoomSettings = (
+  roomId: string,
+  authorId: string,
+  settings: Partial<redis.room.types.Room>,
+) => {
+  return fetchWrapper<void>({
+    url: `/api/rooms/${roomId}/settings`,
+    authorId,
+    body: settings,
+  });
+};

--- a/services/web/src/app/utils/apiRouter.ts
+++ b/services/web/src/app/utils/apiRouter.ts
@@ -21,9 +21,7 @@ export const apiRouter = (handlers: ApiHandlers): NextApiHandler => {
     return handler(req, res)
       .then((data) => {
         if (data == null) {
-          if (res.statusCode === 200) {
-            res.statusCode = 204;
-          }
+          res.statusCode = 204;
         }
         if (data instanceof HttpResult) {
           res.status(data.code).send(data.body);

--- a/services/web/src/app/utils/fetchWrapper.ts
+++ b/services/web/src/app/utils/fetchWrapper.ts
@@ -1,0 +1,28 @@
+import { HttpError } from "@coops/error";
+
+export interface FetchWrapperOptions {
+  url: string;
+  method?: string;
+  authorId?: string;
+  body?: any;
+}
+export const fetchWrapper = async <TResult>({
+  url,
+  method,
+  authorId,
+  body,
+}: FetchWrapperOptions): Promise<TResult> => {
+  const headers: HeadersInit = {};
+  if (authorId != null) {
+    headers.authorization = `X-API-KEY ${authorId}`;
+  }
+  const res = await fetch(url, { method, headers, body: JSON.stringify(body) });
+  if (res.status >= 400) {
+    throw new HttpError(res.status as any, res.statusText);
+  }
+  if (res.status !== 204) {
+    const data = await res.json();
+    return data as TResult;
+  }
+  return {} as TResult;
+};


### PR DESCRIPTION
- 저장하면 포매터 작동함
- 방 관리자 위임 기능 구현
- client-side의 API fetcher 구현

# Example
```ts
// import from /services/web/src/app/queries/*.ts

// usage
await pushChat(roomId, authorId, "xoaxbqmrnehr");

const room = await getRoom(roomId, authorId);
room.title
```